### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-review.yml
+++ b/.github/workflows/quality-review.yml
@@ -1,4 +1,6 @@
 name: Quality Review
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wuerzle/hass-jarolift/security/code-scanning/1](https://github.com/wuerzle/hass-jarolift/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to limit the `GITHUB_TOKEN` permissions used by the workflow. The most secure and standard approach is to add a `permissions:` block at the root of the workflow (at the top level, before the `jobs:` field), so all jobs in the workflow inherit the setting. For this kind of code quality/linting workflow, `contents: read` is sufficient and is the minimal necessary permission set. To do this, insert the following after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```
This change preserves all existing functionality, ensures no unnecessary privileges are granted, and is future-proofed in case actions are added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
